### PR TITLE
Update endpoints that display profile icons to include profile images

### DIFF
--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
@@ -22,6 +22,8 @@
   margin: 20px auto 5px auto;
   border-radius: 50%;
   -webkit-border-radius: 50%;
+  background-position: center;
+  background-size: cover;
 }
 
 .initial {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -21,6 +21,7 @@ export default Vue.extend({
     },
     profileImageUrl: {
       type: String,
+      default: '',
       required: false
     }
   },

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -18,11 +18,19 @@ export default Vue.extend({
     textColor: {
       type: String,
       required: true
+    },
+    profileImageUrl: {
+      type: String,
+      required: false
     }
   },
   computed: {
     profileInitial: function () {
       return this?.profileName?.length > 0 ? Array.from(this.profileName)[0].toUpperCase() : ''
+    },
+    hasProfileImage: function () {
+      // the profile image url should both exist and be a non-empty string
+      return this?.profileImageUrl && !this.profileImageUrl?.length > 0
     }
   },
   methods: {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
@@ -7,8 +7,7 @@
       v-if="hasProfileImage"
       class="bubble"
       :style="{ backgroundImage: profileImageUrl }"
-    >
-    </div>
+    />
     <div
       v-else
       class="bubble"

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
@@ -4,6 +4,13 @@
     @click="goToProfile"
   >
     <div
+      v-if="hasProfileImage"
+      class="bubble"
+      :style="{ backgroundImage: profileImageUrl }"
+    >
+    </div>
+    <div
+      v-else
       class="bubble"
       :style="{ background: backgroundColor, color: textColor }"
     >

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -35,6 +35,7 @@ export default Vue.extend({
       profileName: '',
       profileBgColor: '',
       profileTextColor: '',
+      profileImageUrl: '',
       profileSubscriptions: [],
       deletePromptValues: [
         'yes',
@@ -51,6 +52,10 @@ export default Vue.extend({
     },
     profileInitial: function () {
       return this?.profileName?.length > 0 ? Array.from(this.profileName)[0].toUpperCase() : ''
+    },
+    hasProfileImage: function () {
+      // the profile image url should both exist and be a non-empty string
+      return this?.profileImageUrl && !this.profileImageUrl?.length > 0
     },
     profileList: function () {
       return this.$store.getters.getProfileList
@@ -81,6 +86,7 @@ export default Vue.extend({
     this.profileName = this.profile.name
     this.profileBgColor = this.profile.bgColor
     this.profileTextColor = this.profile.textColor
+    this.profileImageUrl = this.profile.imageUrl
   },
   methods: {
     openDeletePrompt: function () {
@@ -104,6 +110,7 @@ export default Vue.extend({
         name: this.profileName,
         bgColor: this.profileBgColor,
         textColor: this.profileTextColor,
+        imageUrl: this.profileImageUrl,
         subscriptions: this.profile.subscriptions
       }
 

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -49,6 +49,13 @@
         class="bottomMargin"
       >
         <div
+          v-if="hasProfileImage"
+          class="colorOption"
+          :style="{ backgroundImage: profileImageUrl }"
+        >
+        </div>
+        <div
+          v-else
           class="colorOption"
           :style="{ background: profileBgColor, color: profileTextColor }"
           style="cursor: default"

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -52,8 +52,7 @@
           v-if="hasProfileImage"
           class="colorOption"
           :style="{ backgroundImage: profileImageUrl }"
-        >
-        </div>
+        />
         <div
           v-else
           class="colorOption"

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -7,6 +7,8 @@
   justify-content: center;
   border-radius: 50%;
   -webkit-border-radius: 50%;
+  background-position: center;
+  background-size: cover;
 }
 
 .colorOption:hover {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.js
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.js
@@ -35,6 +35,10 @@ export default Vue.extend({
       return this.profileList.map((profile) => {
         return profile?.name?.length > 0 ? Array.from(profile.name)[0].toUpperCase() : ''
       })
+    },
+    hasProfileImage: function () {
+      // the profile image url should both exist and be a non-empty string
+      return this?.activeProfile?.imageUrl && !this.activeProfile.imageUrl?.length > 0
     }
   },
   methods: {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
@@ -1,6 +1,15 @@
 <template>
   <div>
     <div
+      v-if="hasProfileImage"
+      class="colorOption"
+      :style="{ backgroundImage: activeProfile.imageUrl }"
+      @click="toggleProfileList"
+      @mousedown="handleIconMouseDown"
+    >
+    </div>
+    <div
+      v-else
       class="colorOption"
       :style="{ background: activeProfile.bgColor, color: activeProfile.textColor }"
       @click="toggleProfileList"
@@ -39,6 +48,13 @@
           @click="setActiveProfile(profile)"
         >
           <div
+            v-if="hasProfileImage"
+            class="colorOption"
+            :style="{ backgroundImage: profile.imageUrl }"
+          >
+          </div>
+          <div
+            v-else
             class="colorOption"
             :style="{ background: profile.bgColor, color: profile.textColor }"
           >

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
@@ -6,8 +6,7 @@
       :style="{ backgroundImage: activeProfile.imageUrl }"
       @click="toggleProfileList"
       @mousedown="handleIconMouseDown"
-    >
-    </div>
+    />
     <div
       v-else
       class="colorOption"
@@ -51,8 +50,7 @@
             v-if="hasProfileImage"
             class="colorOption"
             :style="{ backgroundImage: profile.imageUrl }"
-          >
-          </div>
+          />
           <div
             v-else
             class="colorOption"

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -8,6 +8,7 @@ const state = {
     name: 'All Channels',
     bgColor: '#000000',
     textColor: '#FFFFFF',
+    imageUrl: null,
     subscriptions: []
   }],
   activeProfile: MAIN_PROFILE_ID


### PR DESCRIPTION
# Title
Frontend and middleware for other locations in the app to correctly display profile images 

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #5 and #1 

## Description
There are existing endpoints to save a profile on the \src\renderer\store\modules\profiles.js and \src\renderer\components\ft-profile-edit\ft-profile-edit.js. This adds "imageUrl" as one of the attributes saved.

Elsewhere in the app, profile icons are displayed in four places. These are all updated to support profile images if they exist.
- Top right nav bar
- Profile Select dropdown
- Profile Manager page
- Edit Profile page

The view (and CSS) and controller are updated to support this change.