### PR TITLE
Profile pictures middle & backend integration

### DIFF
--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -19,9 +19,13 @@ export default Vue.extend({
       type: String,
       required: true
     },
+    picturePresent: {
+      type: Boolean,
+      required: true
+    },
     picture: {
       type: String,
-      required: true,
+      required: true
     }
   },
   computed: {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -20,8 +20,9 @@ export default Vue.extend({
       required: true
     },
     picture: {
-      type: Image,
-      required: false
+      type: String,
+      required: false,
+      default: ''
     }
   },
   computed: {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -18,6 +18,10 @@ export default Vue.extend({
     textColor: {
       type: String,
       required: true
+    },
+    picture: {
+      type: Image,
+      required: false
     }
   },
   computed: {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -21,8 +21,7 @@ export default Vue.extend({
     },
     picture: {
       type: String,
-      required: false,
-      default: ''
+      required: true,
     }
   },
   computed: {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
@@ -18,4 +18,4 @@
 </template>
 
 <script src="./ft-profile-bubble.js" />
-<style scoped src="./ft-profile-bubble.css" />
+<style scoped src="./ft-profile-bubble.css" /> -->

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
@@ -3,14 +3,7 @@
     class="bubblePadding"
     @click="goToProfile"
   >
-    <div v-if="picture">
-        <img
-            :src="picture"
-            class="bubble"
-            contain
-          >
-    </div>
-    <div v-else
+    <div
       class="bubble"
       :style="{ background: backgroundColor, color: textColor }"
     >

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
@@ -3,7 +3,14 @@
     class="bubblePadding"
     @click="goToProfile"
   >
-    <div
+    <div v-if="picture">
+        <img
+            :src="picture"
+            class="bubble"
+            contain
+          >
+    </div>
+    <div v-else
       class="bubble"
       :style="{ background: backgroundColor, color: textColor }"
     >

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.css
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.css
@@ -43,3 +43,42 @@
     width: 90%;
   }
 }
+.dropbox {
+  outline: 2px dashed grey; /* the dash box */
+  outline-offset: -10px;
+  background: lightcyan;
+  color: dimgray;
+  padding: 10px 10px;
+  min-height: 200px; /* minimum height */
+  position: relative;
+  cursor: pointer;
+}
+
+.input-file {
+  opacity: 0; /* invisible but it's there! */
+  width: 100%;
+  height: 200px;
+  position: absolute;
+  cursor: pointer;
+}
+
+.dropbox:hover {
+  background: lightblue; /* when mouse over to the drop zone, change color */
+}
+
+.dropbox p {
+  font-size: 1.2em;
+  text-align: center;
+  padding: 50px 0;
+}
+
+.default-upload {
+  position: absolute;
+  z-index: 1000;
+  opacity: 0;
+  cursor: pointer;
+  right: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+}

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -34,6 +34,7 @@ export default Vue.extend({
       profileId: '',
       profileName: '',
       profileBgColor: '',
+      profilePicture: null,
       profileTextColor: '',
       profileSubscriptions: [],
       deletePromptValues: [
@@ -74,11 +75,15 @@ export default Vue.extend({
   watch: {
     profileBgColor: function (val) {
       this.profileTextColor = calculateColorLuminance(val)
+    },
+    profilePicture: function (img) {
+      this.profilePicture = img
     }
   },
   created: function () {
     this.profileId = this.$route.params.id
     this.profileName = this.profile.name
+    this.profilePicture = this.profile.picture
     this.profileBgColor = this.profile.bgColor
     this.profileTextColor = this.profile.textColor
   },
@@ -103,6 +108,7 @@ export default Vue.extend({
       const profile = {
         name: this.profileName,
         bgColor: this.profileBgColor,
+        picture: this.profilePicture,
         textColor: this.profileTextColor,
         subscriptions: this.profile.subscriptions
       }
@@ -155,6 +161,10 @@ export default Vue.extend({
       'removeProfile',
       'updateDefaultProfile',
       'updateActiveProfile'
-    ])
+    ]),
+
+    profilePictureUpload: function (event) {
+      this.profilePicture = event.target.files[0]
+    }
   }
 })

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -9,6 +9,7 @@ import { MAIN_PROFILE_ID } from '../../../constants'
 import { calculateColorLuminance, colors } from '../../helpers/colors'
 import { showToast } from '../../helpers/utils'
 import { throwDeprecation } from 'process'
+import { threadId } from 'worker_threads'
 
 export default Vue.extend({
   name: 'FtProfileEdit',
@@ -77,9 +78,6 @@ export default Vue.extend({
   watch: {
     profileBgColor: function (val) {
       this.profileTextColor = calculateColorLuminance(val)
-    },
-    profilePicture: function (img) {
-      this.profilePicture = img
     }
   },
   created: function () {
@@ -111,6 +109,7 @@ export default Vue.extend({
       const profile = {
         name: this.profileName,
         bgColor: this.profileBgColor,
+        picturePresent: this.picturePresent,
         picture: this.profilePicture,
         textColor: this.profileTextColor,
         subscriptions: this.profile.subscriptions

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -8,6 +8,7 @@ import FtButton from '../../components/ft-button/ft-button.vue'
 import { MAIN_PROFILE_ID } from '../../../constants'
 import { calculateColorLuminance, colors } from '../../helpers/colors'
 import { showToast } from '../../helpers/utils'
+import { throwDeprecation } from 'process'
 
 export default Vue.extend({
   name: 'FtProfileEdit',
@@ -34,7 +35,8 @@ export default Vue.extend({
       profileId: '',
       profileName: '',
       profileBgColor: '',
-      profilePicture: null,
+      profilePicturePresent: false,
+      profilePicture: '',
       profileTextColor: '',
       profileSubscriptions: [],
       deletePromptValues: [
@@ -83,6 +85,7 @@ export default Vue.extend({
   created: function () {
     this.profileId = this.$route.params.id
     this.profileName = this.profile.name
+    this.profilePicturePresent = this.profile.picturePresent
     this.profilePicture = this.profile.picture
     this.profileBgColor = this.profile.bgColor
     this.profileTextColor = this.profile.textColor
@@ -164,8 +167,14 @@ export default Vue.extend({
     ]),
 
     profilePictureUpload: function (event) {
+      this.profilePicturePresent = true
       const file = event.target.files[0]
       this.profilePicture = URL.createObjectURL(file)
+    },
+
+    profileColorChange: function (color) {
+      this.profilePicturePresent = false
+      this.profileBgColor = color
     }
   }
 })

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -164,7 +164,8 @@ export default Vue.extend({
     ]),
 
     profilePictureUpload: function (event) {
-      this.profilePicture = event.target.files[0]
+      const file = event.target.files[0]
+      this.profilePicture = URL.createObjectURL(file)
     }
   }
 })

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -18,6 +18,7 @@
           <input
             type="file"
             class="default-upload"
+            @click = "profilePicturePresent = true"
             @change="profilePictureUpload"
           >
         </ft-button>
@@ -31,7 +32,7 @@
           :key="index"
           class="colorOption"
           :style="{ background: color }"
-          @click="profileBgColor = color"
+          @click="profileColorChange(color)"
         />
       </ft-flex-box>
       <ft-flex-box
@@ -59,7 +60,7 @@
       <ft-flex-box
         class="bottomMargin"
       >
-        <div v-if="profilePicture">
+        <div v-if="profilePicturePresent">
           <img
             :src="profilePicture"
             class="colorOption"

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -19,7 +19,7 @@
             type="file"
             class="default-upload"
             @change="profilePictureUpload"
-          />
+          >
         </ft-button>
       </ft-flex-box>
       <h3>{{ $t("Profile.Color Picker") }}</h3>
@@ -59,7 +59,15 @@
       <ft-flex-box
         class="bottomMargin"
       >
+        <div v-if="profilePicture">
+          <img
+            :src="profilePicture"
+            class="colorOption"
+            contain
+          >
+        </div>
         <div
+          v-else
           class="colorOption"
           :style="{ background: profileBgColor, color: profileTextColor }"
           style="cursor: default"

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -11,6 +11,17 @@
           @input="e => profileName = e"
         />
       </ft-flex-box>
+      <h3>{{ $t("Profile.Upload Profile Picture") }}</h3>
+      <ft-flex-box>
+        <ft-button>
+          <p>{{ $t("Profile.Choose an Image") }}</p>
+          <input
+            type="file"
+            class="default-upload"
+            @change="profilePictureUpload"
+          />
+        </ft-button>
+      </ft-flex-box>
       <h3>{{ $t("Profile.Color Picker") }}</h3>
       <ft-flex-box
         class="bottomMargin colorOptions"

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -18,7 +18,7 @@
           <input
             type="file"
             class="default-upload"
-            @click = "profilePicturePresent = true"
+            @click="profilePicturePresent = true"
             @change="profilePictureUpload"
           >
         </ft-button>


### PR DESCRIPTION
# Title
Frontend and middleware for other locations in the app to correctly display profile images 

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #5 and #1 

## Description
There are existing endpoints to save a profile on the \src\renderer\store\modules\profiles.js and \src\renderer\components\ft-profile-edit\ft-profile-edit.js. This adds "imageUrl" as one of the attributes saved.

Elsewhere in the app, profile icons are displayed in four places. These are all updated to support profile images if they exist.
- Top right nav bar
- Profile Select dropdown
- Profile Manager page
- Edit Profile page

The view (and CSS) and controller are updated to support this change.