### PR TITLE
Added field to profile and set method

### DIFF
--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -18,6 +18,10 @@ export default Vue.extend({
     textColor: {
       type: String,
       required: true
+    },
+    profileImg: {
+      type: Image,
+      required: false
     }
   },
   computed: {

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -35,6 +35,7 @@ export default Vue.extend({
       profileName: '',
       profileBgColor: '',
       profileTextColor: '',
+      profileImg: null,
       profileSubscriptions: [],
       deletePromptValues: [
         'yes',
@@ -74,12 +75,16 @@ export default Vue.extend({
   watch: {
     profileBgColor: function (val) {
       this.profileTextColor = calculateColorLuminance(val)
+    },
+    profileImg: function (img) {
+      this.profileImg = img
     }
   },
   created: function () {
     this.profileId = this.$route.params.id
     this.profileName = this.profile.name
     this.profileBgColor = this.profile.bgColor
+    this.profileImg = this.profile.profileImg
     this.profileTextColor = this.profile.textColor
   },
   methods: {
@@ -104,6 +109,7 @@ export default Vue.extend({
         name: this.profileName,
         bgColor: this.profileBgColor,
         textColor: this.profileTextColor,
+        profileImg: this.profileImg,
         subscriptions: this.profile.subscriptions
       }
 


### PR DESCRIPTION
# Title
Frontend and middleware for other locations in the app to correctly display profile images 

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #5 and #1 

## Description
There are existing endpoints to save a profile on the \src\renderer\store\modules\profiles.js and \src\renderer\components\ft-profile-edit\ft-profile-edit.js. This adds "imageUrl" as one of the attributes saved.

Elsewhere in the app, profile icons are displayed in four places. These are all updated to support profile images if they exist.
- Top right nav bar
- Profile Select dropdown
- Profile Manager page
- Edit Profile page

The view (and CSS) and controller are updated to support this change.