### PR TITLE
Merge profile picture integration

### DIFF
--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
@@ -22,6 +22,8 @@
   margin: 20px auto 5px auto;
   border-radius: 50%;
   -webkit-border-radius: 50%;
+  background-position: center;
+  background-size: cover;
 }
 
 .initial {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -18,11 +18,20 @@ export default Vue.extend({
     textColor: {
       type: String,
       required: true
+    },
+    profileImageUrl: {
+      type: String,
+      default: '',
+      required: false
     }
   },
   computed: {
     profileInitial: function () {
       return this?.profileName?.length > 0 ? Array.from(this.profileName)[0].toUpperCase() : ''
+    },
+    hasProfileImage: function () {
+      // the profile image url should both exist and be a non-empty string
+      return this?.profileImageUrl && !this.profileImageUrl?.length > 0
     }
   },
   methods: {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.js
@@ -21,8 +21,7 @@ export default Vue.extend({
     },
     profileImageUrl: {
       type: String,
-      default: '',
-      required: false
+      required: true
     }
   },
   computed: {
@@ -31,7 +30,7 @@ export default Vue.extend({
     },
     hasProfileImage: function () {
       // the profile image url should both exist and be a non-empty string
-      return this?.profileImageUrl && !this.profileImageUrl?.length > 0
+      return this?.profileImageUrl && this.profileImageUrl?.length > 0
     }
   },
   methods: {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.vue
@@ -4,6 +4,12 @@
     @click="goToProfile"
   >
     <div
+      v-if="hasProfileImage"
+      class="bubble"
+      :style="{ backgroundImage: `url(${profileImageUrl})` }"
+    />
+    <div
+      v-else
       class="bubble"
       :style="{ background: backgroundColor, color: textColor }"
     >

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.css
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.css
@@ -43,3 +43,43 @@
     width: 90%;
   }
 }
+
+.dropbox {
+  outline: 2px dashed grey; /* the dash box */
+  outline-offset: -10px;
+  background: lightcyan;
+  color: dimgray;
+  padding: 10px 10px;
+  min-height: 200px; /* minimum height */
+  position: relative;
+  cursor: pointer;
+}
+
+.input-file {
+  opacity: 0; /* invisible but it's there! */
+  width: 100%;
+  height: 200px;
+  position: absolute;
+  cursor: pointer;
+}
+
+.dropbox:hover {
+  background: lightblue; /* when mouse over to the drop zone, change color */
+}
+
+.dropbox p {
+  font-size: 1.2em;
+  text-align: center;
+  padding: 50px 0;
+}
+
+.default-upload {
+  position: absolute;
+  z-index: 1000;
+  opacity: 0;
+  cursor: pointer;
+  right: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+}

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.css
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.css
@@ -29,6 +29,8 @@
   cursor: pointer;
   border-radius: 50%;
   -webkit-border-radius: 50%;
+  background-position: center;
+  background-size: cover;
 }
 
 .initial {

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -106,6 +106,7 @@ export default Vue.extend({
         showToast(this.$t('Profile.Your profile name cannot be empty'))
         return
       }
+      alert(this.profileImageUrl)
       const profile = {
         name: this.profileName,
         bgColor: this.profileBgColor,
@@ -165,34 +166,31 @@ export default Vue.extend({
     ]),
 
     profileImageUpload: function (event) {
-      console.log("hello")
-      console.log(event.target.files[0])
       const file = event.target.files[0]
-      const acceptedImageTypes = ['image/gif', 'image/jpeg', 'image/png']
+      // const acceptedImageTypes = ['image/gif', 'image/jpeg', 'image/png']
 
-      if (file && acceptedImageTypes.includes(file.type)) {
-        this.profileImageUrl = URL.createObjectURL(file)
-      }
-      else {
-        showToast(this.$t('Profile.File upload not successful'))
-      }
-      return
+      // if (file && acceptedImageTypes.includes(file.type)) {
+      //   this.profileImageUrl = URL.createObjectURL(file)
+      // }
+      // else {
+      //   showToast(this.$t('Profile.File upload not successful'))
+      // }
+      // return
       if (file.size > 64000) {
         showToast(this.$t('Profile image must be smaller than 64KB'))
         return
       }
-      const reader = new FileReader();
-      reader.readAsDataURL(file);
+      const reader = new FileReader()
+      reader.readAsDataURL(file)
       reader.onload = function () {
-        console.log(reader.result);
-        this.profileImageUrl = reader.result.toString()
-        this.profileBgColor = "#FFFFFF"
+        this.profileImageUrl = reader.result
+        this.profileBgColor = '#FFFFFF'
         // console.log(this.profileImageUrl)
-      };
-      reader.onerror = function (error) {
-        console.log('Error: ', error);
-        return
-      };
+        // console.log(this.profileImageUrl.toString())
+      }
+      // reader.onerror = function (error) {
+      //   console.log('Error: ', error)
+      // }
     }
   }
 })

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -35,6 +35,7 @@ export default Vue.extend({
       profileName: '',
       profileBgColor: '',
       profileTextColor: '',
+      profileImageUrl: '',
       profileSubscriptions: [],
       deletePromptValues: [
         'yes',
@@ -51,6 +52,10 @@ export default Vue.extend({
     },
     profileInitial: function () {
       return this?.profileName?.length > 0 ? Array.from(this.profileName)[0].toUpperCase() : ''
+    },
+    hasProfileImage: function () {
+      // the profile image url should both exist and be a non-empty string
+      return this?.profileImageUrl && !this.profileImageUrl?.length > 0
     },
     profileList: function () {
       return this.$store.getters.getProfileList
@@ -81,6 +86,7 @@ export default Vue.extend({
     this.profileName = this.profile.name
     this.profileBgColor = this.profile.bgColor
     this.profileTextColor = this.profile.textColor
+    this.profileImageUrl = this.profile.imageUrl
   },
   methods: {
     openDeletePrompt: function () {
@@ -104,6 +110,7 @@ export default Vue.extend({
         name: this.profileName,
         bgColor: this.profileBgColor,
         textColor: this.profileTextColor,
+        imageUrl: this.profileImageUrl,
         subscriptions: this.profile.subscriptions
       }
 

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -79,12 +79,16 @@ export default Vue.extend({
   watch: {
     profileBgColor: function (val) {
       this.profileTextColor = calculateColorLuminance(val)
+    },
+    profileImg: function (img) {
+      this.profileImg = img
     }
   },
   created: function () {
     this.profileId = this.$route.params.id
     this.profileName = this.profile.name
     this.profileBgColor = this.profile.bgColor
+    this.profileImg = this.profile.profileImg
     this.profileTextColor = this.profile.textColor
     this.profileImageUrl = this.profile.imageUrl
   },

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -79,16 +79,12 @@ export default Vue.extend({
   watch: {
     profileBgColor: function (val) {
       this.profileTextColor = calculateColorLuminance(val)
-    },
-    profileImg: function (img) {
-      this.profileImg = img
     }
   },
   created: function () {
     this.profileId = this.$route.params.id
     this.profileName = this.profile.name
     this.profileBgColor = this.profile.bgColor
-    this.profileImg = this.profile.profileImg
     this.profileTextColor = this.profile.textColor
     this.profileImageUrl = this.profile.imageUrl
   },

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -33,6 +33,7 @@ export default Vue.extend({
       showDeletePrompt: false,
       profileId: '',
       profileName: '',
+      profilePicture: null,
       profileBgColor: '',
       profileTextColor: '',
       profileImageUrl: '',
@@ -84,6 +85,7 @@ export default Vue.extend({
   created: function () {
     this.profileId = this.$route.params.id
     this.profileName = this.profile.name
+    this.profilePicture = this.profile.picture
     this.profileBgColor = this.profile.bgColor
     this.profileTextColor = this.profile.textColor
     this.profileImageUrl = this.profile.imageUrl
@@ -108,6 +110,7 @@ export default Vue.extend({
       }
       const profile = {
         name: this.profileName,
+        picture: this.profilePicture,
         bgColor: this.profileBgColor,
         textColor: this.profileTextColor,
         imageUrl: this.profileImageUrl,
@@ -162,6 +165,10 @@ export default Vue.extend({
       'removeProfile',
       'updateDefaultProfile',
       'updateActiveProfile'
-    ])
+    ]),
+
+    profilePictureUpload: function (event) {
+      this.profilePicture = event.target.files[0]
+    }
   }
 })

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -33,7 +33,6 @@ export default Vue.extend({
       showDeletePrompt: false,
       profileId: '',
       profileName: '',
-      profilePicture: null,
       profileBgColor: '',
       profileTextColor: '',
       profileImageUrl: '',
@@ -56,7 +55,7 @@ export default Vue.extend({
     },
     hasProfileImage: function () {
       // the profile image url should both exist and be a non-empty string
-      return this?.profileImageUrl && !this.profileImageUrl?.length > 0
+      return this?.profileImageUrl && this.profileImageUrl?.length > 0
     },
     profileList: function () {
       return this.$store.getters.getProfileList
@@ -85,7 +84,6 @@ export default Vue.extend({
   created: function () {
     this.profileId = this.$route.params.id
     this.profileName = this.profile.name
-    this.profilePicture = this.profile.picture
     this.profileBgColor = this.profile.bgColor
     this.profileTextColor = this.profile.textColor
     this.profileImageUrl = this.profile.imageUrl
@@ -110,7 +108,6 @@ export default Vue.extend({
       }
       const profile = {
         name: this.profileName,
-        picture: this.profilePicture,
         bgColor: this.profileBgColor,
         textColor: this.profileTextColor,
         imageUrl: this.profileImageUrl,
@@ -167,8 +164,35 @@ export default Vue.extend({
       'updateActiveProfile'
     ]),
 
-    profilePictureUpload: function (event) {
-      this.profilePicture = event.target.files[0]
+    profileImageUpload: function (event) {
+      console.log("hello")
+      console.log(event.target.files[0])
+      const file = event.target.files[0]
+      const acceptedImageTypes = ['image/gif', 'image/jpeg', 'image/png']
+
+      if (file && acceptedImageTypes.includes(file.type)) {
+        this.profileImageUrl = URL.createObjectURL(file)
+      }
+      else {
+        showToast(this.$t('Profile.File upload not successful'))
+      }
+      return
+      if (file.size > 64000) {
+        showToast(this.$t('Profile image must be smaller than 64KB'))
+        return
+      }
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = function () {
+        console.log(reader.result);
+        this.profileImageUrl = reader.result.toString()
+        this.profileBgColor = "#FFFFFF"
+        // console.log(this.profileImageUrl)
+      };
+      reader.onerror = function (error) {
+        console.log('Error: ', error);
+        return
+      };
     }
   }
 })

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -19,7 +19,7 @@
             type="file"
             class="default-upload"
             @change="profileImageUpload"
-          />
+          >
         </ft-button>
       </ft-flex-box>
       <h3>{{ $t("Profile.Color Picker") }}</h3>

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -49,6 +49,12 @@
         class="bottomMargin"
       >
         <div
+          v-if="hasProfileImage"
+          class="colorOption"
+          :style="{ backgroundImage: `url(${profileImageUrl})` }"
+        />
+        <div
+          v-else
           class="colorOption"
           :style="{ background: profileBgColor, color: profileTextColor }"
           style="cursor: default"

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -11,6 +11,17 @@
           @input="e => profileName = e"
         />
       </ft-flex-box>
+      <h3>{{ $t("Profile.Upload Profile Picture") }}</h3>
+      <ft-flex-box>
+        <ft-button>
+          <p>{{ $t("Profile.Choose an Image") }}</p>
+          <input
+            type="file"
+            class="default-upload"
+            @change="profilePictureUpload"
+          />
+        </ft-button>
+      </ft-flex-box>
       <h3>{{ $t("Profile.Color Picker") }}</h3>
       <ft-flex-box
         class="bottomMargin colorOptions"

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -18,7 +18,7 @@
           <input
             type="file"
             class="default-upload"
-            @change="profilePictureUpload"
+            @change="profileImageUpload"
           />
         </ft-button>
       </ft-flex-box>
@@ -31,7 +31,7 @@
           :key="index"
           class="colorOption"
           :style="{ background: color }"
-          @click="profileBgColor = color"
+          @click="profileBgColor = color; profileImageUrl = '';"
         />
       </ft-flex-box>
       <ft-flex-box

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -7,6 +7,8 @@
   justify-content: center;
   border-radius: 50%;
   -webkit-border-radius: 50%;
+  background-position: center;
+  background-size: cover;
 }
 
 .colorOption:hover {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.js
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.js
@@ -35,6 +35,10 @@ export default Vue.extend({
       return this.profileList.map((profile) => {
         return profile?.name?.length > 0 ? Array.from(profile.name)[0].toUpperCase() : ''
       })
+    },
+    hasProfileImage: function () {
+      // the profile image url should both exist and be a non-empty string
+      return this?.activeProfile?.imageUrl && !this.activeProfile.imageUrl?.length > 0
     }
   },
   methods: {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.js
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.js
@@ -38,7 +38,7 @@ export default Vue.extend({
     },
     hasProfileImage: function () {
       // the profile image url should both exist and be a non-empty string
-      return this?.activeProfile?.imageUrl && !this.activeProfile.imageUrl?.length > 0
+      return this?.activeProfile?.imageUrl && this.activeProfile.imageUrl?.length > 0
     }
   },
   methods: {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
@@ -1,6 +1,14 @@
 <template>
   <div>
     <div
+      v-if="hasProfileImage"
+      class="colorOption"
+      :style="{ backgroundImage: `url(${activeProfile.imageUrl})` }"
+      @click="toggleProfileList"
+      @mousedown="handleIconMouseDown"
+    />
+    <div
+      v-else
       class="colorOption"
       :style="{ background: activeProfile.bgColor, color: activeProfile.textColor }"
       @click="toggleProfileList"
@@ -39,6 +47,12 @@
           @click="setActiveProfile(profile)"
         >
           <div
+            v-if="hasProfileImage"
+            class="colorOption"
+            :style="{ backgroundImage: `url(${profile.imageUrl})` }"
+          />
+          <div
+            v-else
             class="colorOption"
             :style="{ background: profile.bgColor, color: profile.textColor }"
           >

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -8,6 +8,7 @@ const state = {
     name: 'All Channels',
     bgColor: '#000000',
     textColor: '#FFFFFF',
+    imageUrl: null,
     subscriptions: []
   }],
   activeProfile: MAIN_PROFILE_ID

--- a/src/renderer/views/ProfileSettings/ProfileSettings.vue
+++ b/src/renderer/views/ProfileSettings/ProfileSettings.vue
@@ -12,6 +12,7 @@
           :profile-name="profile.name"
           :background-color="profile.bgColor"
           :text-color="profile.textColor"
+          :profile-image-url="profile.imageUrl"
         />
       </ft-flex-box>
       <ft-flex-box>

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -498,6 +498,8 @@ Profile:
   Profile Manager: 'مدير الملف الشخصي'
   Create New Profile: 'إنشاء ملف شخصي جديد'
   Edit Profile: 'تعديل الملف الشخصي'
+  Upload Profile Picture: 'تحميل صورة الملف الشخصي'
+  Choose an Image: 'اختر صورة'
   Color Picker: 'أداة انتقاء اللون'
   Custom Color: 'لون مخصص'
   Profile Preview: 'معاينة الملف الشخصي'

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -389,6 +389,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -512,6 +512,8 @@ Profile:
   Profile Manager: 'Управление на профили'
   Create New Profile: 'Създаване на нов профил'
   Edit Profile: 'Редактиране на профил'
+  Upload Profile Picture: 'качи профилна снимка'
+  Choose an Image: 'изберете изображение'
   Color Picker: 'Избор на цвят'
   Custom Color: 'Потребителски цвят'
   Profile Preview: 'Преглед на профила'

--- a/static/locales/bn.yaml
+++ b/static/locales/bn.yaml
@@ -281,6 +281,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/bs.yaml
+++ b/static/locales/bs.yaml
@@ -293,6 +293,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/ca.yaml
+++ b/static/locales/ca.yaml
@@ -430,6 +430,8 @@ Profile:
   Profile Manager: 'Gestor de Perfils'
   Create New Profile: 'Crea un Nou Perfil'
   Edit Profile: 'Editar el perfil'
+  Upload Profile Picture: 'Carregueu la imatge de perfil'
+  Choose an Image: 'Trieu una imatge'
   Color Picker: 'Selector de colors'
   Custom Color: 'Color personalitzat'
   Profile Preview: 'Vista prèvia del perfil'

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -502,6 +502,8 @@ Profile:
   Profile Manager: 'Správce profilu'
   Create New Profile: 'Vytvořit nový profil'
   Edit Profile: 'Editovat profil'
+  Upload Profile Picture: 'Nahrajte profilový obrázek'
+  Choose an Image: 'Vyberte obrázek'
   Color Picker: 'Výběr barvy'
   Custom Color: 'Vlastní barva'
   Profile Preview: 'Náhled profilu'

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -487,6 +487,8 @@ Profile:
   Profile Manager: 'Profilhåndtering'
   Create New Profile: 'Opret Ny Profil'
   Edit Profile: 'Redigér Profil'
+  Upload Profile Picture: 'Upload profilbillede'
+  Choose an Image: 'Vælg et billede'
   Color Picker: 'Farvevælger'
   Custom Color: 'Tilpasset Farve'
   Profile Preview: 'Forhåndsvisning af Profil'

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -832,6 +832,8 @@ Profile:
   Custom Color: Benutzerdefinierte Farbe
   Color Picker: Farbauswahl
   Edit Profile: Profil bearbeiten
+  Upload Profile Picture: Profilbild hochladen
+  Choose an Image: Wählen Sie ein Bild aus
   Create New Profile: Neues Profil erstellen
   Profile Manager: Profilverwalter
   All Channels: Alle Kanäle

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -451,6 +451,8 @@ Profile:
   Profile Manager: 'Διαχειριστής Προφίλ'
   Create New Profile: 'Δημιουργία νέου Προφίλ'
   Edit Profile: 'Επεξεργασία προφίλ'
+  Upload Profile Picture: 'Μεταφόρτωση εικόνας προφίλ'
+  Choose an Image: 'Επιλέξτε μια εικόνα'
   Color Picker: 'Επιλογέας χρώματος'
   Custom Color: 'Προσαρμοσμένο Χρώμα'
   Profile Preview: 'Προεπισκόπηση προφίλ'

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -450,6 +450,8 @@ Profile:
   Profile Manager: Profile Manager
   Create New Profile: Create New Profile
   Edit Profile: Edit Profile
+  Upload Profile Picture: Upload Profile Picture
+  Choose an Image: Choose an Image
   Color Picker: Color Picker
   Custom Color: Custom Color
   Profile Preview: Profile Preview

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -488,6 +488,8 @@ Profile:
   Profile Manager: 'Profile Manager'
   Create New Profile: 'Create New Profile'
   Edit Profile: 'Edit Profile'
+  Upload Profile Picture: 'Upload Profile Picture'
+  Choose an Image: 'Choose an Image'
   Color Picker: 'Colour Picker'
   Custom Color: 'Custom Colour'
   Profile Preview: 'Profile Preview'

--- a/static/locales/eo.yaml
+++ b/static/locales/eo.yaml
@@ -275,6 +275,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -719,6 +719,8 @@ Profile:
   Custom Color: Color personalizado
   Color Picker: Selector de color
   Edit Profile: Editar Perfil
+  Upload Profile Picture: Subir foto de perfil
+  Choose an Image: Elige una imagen
   Create New Profile: Crear Perfil Nuevo
   Profile Manager: Gestor de Perfiles
   All Channels: Todos Los Canales

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -506,6 +506,8 @@ Profile:
   Profile Manager: 'Administrador de perfiles'
   Create New Profile: 'Crear nuevo perfil'
   Edit Profile: 'Editar perfil'
+  Upload Profile Picture: 'Subir foto de perfil'
+  Choose an Image: 'Elige una imagen'
   Color Picker: 'Selector de color'
   Custom Color: 'Color personalizado'
   Profile Preview: 'Vista previa del perfil'

--- a/static/locales/es_AR.yaml
+++ b/static/locales/es_AR.yaml
@@ -337,6 +337,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -470,6 +470,8 @@ Profile:
   Profile Manager: 'Profiilihaldur'
   Create New Profile: 'Loo uus profiil'
   Edit Profile: 'Muuda profiili'
+  Upload Profile Picture: 'Laadige üles profiilipilt'
+  Choose an Image: 'Valige pilt'
   Color Picker: 'Vali värv'
   Custom Color: 'Vali täpne värv'
   Profile Preview: 'Profiili eelvaade'

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -438,6 +438,8 @@ Profile:
   Profile Manager: 'Profilaren kudeatzailea'
   Create New Profile: 'Profil berria sortu'
   Edit Profile: 'Profila editatu'
+  Upload Profile Picture: 'Kargatu profileko argazkia'
+  Choose an Image: 'Aukeratu Irudi bat'
   Color Picker: 'Kolore hautatzailea'
   Custom Color: 'Kolore lehenetsia'
   Profile Preview: 'Profilaren aurreikuspena'

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -375,6 +375,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -779,6 +779,8 @@ Profile:
   Custom Color: Mukautettu väri
   Color Picker: Värin valinta
   Edit Profile: Muokkaa profiilia
+  Upload Profile Picture: Lataa profiilikuva
+  Choose an Image: Valitse kuva
   Create New Profile: Luo uusi profiili
   Profile Manager: Profiilin hallinta
   All Channels: Kaikki kanavat

--- a/static/locales/fil.yaml
+++ b/static/locales/fil.yaml
@@ -263,6 +263,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -836,6 +836,8 @@ Profile:
   Custom Color: Couleur personnalisée
   Color Picker: Sélecteur de couleurs
   Edit Profile: Modifier le profil
+  Upload Profile Picture: Télécharger une photo de profil
+  Choose an Image: Choisissez une image
   Create New Profile: Créer un nouveau profil
   Profile Manager: Gestionnaire de profil
   All Channels: Tous les chaînes

--- a/static/locales/gl.yaml
+++ b/static/locales/gl.yaml
@@ -513,6 +513,8 @@ Profile:
   Profile Manager: 'Xestor de perfís'
   Create New Profile: 'Crear novo perfil'
   Edit Profile: 'Editar perfil'
+  Upload Profile Picture: 'Cargar imaxe de perfil'
+  Choose an Image: 'Escolle unha imaxe'
   Color Picker: 'Selector de cor'
   Custom Color: 'Cor personalizada'
   Profile Preview: 'Vista previa do perfil'

--- a/static/locales/gsw.yaml
+++ b/static/locales/gsw.yaml
@@ -418,6 +418,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -502,6 +502,8 @@ Profile:
   Profile Manager: 'מנהל הפרופילים'
   Create New Profile: 'צרו פרופיל חדש'
   Edit Profile: 'עריכת פרופיל'
+  Upload Profile Picture: 'העלה תמונת פרופיל'
+  Choose an Image: 'בחר תמונה'
   Color Picker: 'בוחר הצבע'
   Custom Color: 'צבע אחר'
   Profile Preview: 'לוגו הפרופיל'

--- a/static/locales/hi.yaml
+++ b/static/locales/hi.yaml
@@ -301,6 +301,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -514,6 +514,8 @@ Profile:
   Profile Manager: 'Upravljač profila'
   Create New Profile: 'Stvori novi profil'
   Edit Profile: 'Uredi profil'
+  Upload Profile Picture: 'Prenesi sliku profila'
+  Choose an Image: 'Odaberite sliku'
   Color Picker: 'Birač boja'
   Custom Color: 'Prilagođena boja'
   Profile Preview: 'Pregled profila'

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -519,6 +519,8 @@ Profile:
   Profile Manager: 'Profilkezelő'
   Create New Profile: 'Új profil létrehozása'
   Edit Profile: 'Profil szerkesztése'
+  Upload Profile Picture: 'Profilkép feltöltése'
+  Choose an Image: 'Válasszon egy képet'
   Color Picker: 'Színválasztó'
   Custom Color: 'Egyéni szín'
   Profile Preview: 'Profil előnézet'

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -435,6 +435,8 @@ Profile:
   Profile Manager: 'Pengelola Profil'
   Create New Profile: 'Buat Profil Baru'
   Edit Profile: 'Sunting Profil'
+  Upload Profile Picture: 'Unggah Gambar Profil'
+  Choose an Image: 'Pilih Gambar'
   Color Picker: 'Pemilih Warna'
   Custom Color: 'Warna Khusus'
   Profile Preview: 'Pratinjau Profil'

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -459,6 +459,8 @@ Profile:
   Profile Manager: 'Sýsla með notkunarsnið'
   Create New Profile: 'Búa til nýtt notkunarsnið'
   Edit Profile: 'Breyta notkunarsniði'
+  Upload Profile Picture: 'Hladdu upp prófílmynd'
+  Choose an Image: 'Veldu mynd'
   Color Picker: 'Litaplokkari'
   Custom Color: 'Sérsniðinn litur'
   Profile Preview: 'Forskoðun notkunarsniðs'

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -835,6 +835,8 @@ Profile:
   Custom Color: Colore personalizzato
   Color Picker: Selettore del colore
   Edit Profile: Modifica il profilo
+  Upload Profile Picture: Carica l'immagine del profilo
+  Choose an Image: Scegli un'immagine
   Create New Profile: Crea un nuovo profilo
   Profile Manager: Gestione dei profili
   All Channels: Tutti i canali

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -734,6 +734,8 @@ Profile:
   Custom Color: 色の指定
   Color Picker: 色の選択
   Edit Profile: プロファイルの編集
+  Upload Profile Picture: プロフィール写真をアップロード
+  Choose an Image: 画像を選択
   Create New Profile: プロファイルの新規作成
   Profile Manager: プロファイル管理
   All Channels: すべてのチャンネル

--- a/static/locales/ka.yaml
+++ b/static/locales/ka.yaml
@@ -430,6 +430,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/km.yaml
+++ b/static/locales/km.yaml
@@ -352,6 +352,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/ko.yaml
+++ b/static/locales/ko.yaml
@@ -451,6 +451,8 @@ Profile:
   Profile Manager: '프로필 관리자'
   Create New Profile: '새 프로파일 작성'
   Edit Profile: '프로필 편집'
+  Upload Profile Picture: '프로필 사진 업로드'
+  Choose an Image: '이미지를 선택하세요'
   Color Picker: '색상 선택기'
   Custom Color: '사용자 지정 색'
   Profile Preview: '프로필 미리보기'

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -324,6 +324,8 @@ Profile:
   Profile Manager: 'ڕێخەری پڕۆفایل'
   Create New Profile: 'پڕۆفایلێکی نوێ دروستبکە'
   Edit Profile: 'پڕۆفایل دەستکاری بکە'
+  Upload Profile Picture: 'بارکردنی وێنەی پرۆفایل'
+  Choose an Image: 'وێنەیەک هەڵبژێرە'
   Color Picker: 'ڕەنگ هەڵبژاردەر'
   Custom Color: 'رەنگی تایبەت'
   Profile Preview: 'پڕۆفایل بیشاندە'

--- a/static/locales/la.yaml
+++ b/static/locales/la.yaml
@@ -286,6 +286,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/lt.yaml
+++ b/static/locales/lt.yaml
@@ -460,6 +460,8 @@ Profile:
   Profile Manager: 'Profilio valdymas'
   Create New Profile: 'Sukurti naują profilį'
   Edit Profile: 'Redaguoti profilį'
+  Upload Profile Picture: 'Įkelti profilio nuotrauką'
+  Choose an Image: 'Pasirinkite vaizdą'
   Color Picker: 'Spalvų rinkiklis'
   Custom Color: 'Pasirinktinė spalva'
   Profile Preview: 'Profilio peržiūra'

--- a/static/locales/nb_NO.yaml
+++ b/static/locales/nb_NO.yaml
@@ -714,6 +714,8 @@ Profile:
   Profile Select: Velg profil
   Create Profile: Lag profil
   Edit Profile: Rediger profil
+  Upload Profile Picture: Last opp profilbilde
+  Choose an Image: Velg et bilde
   Create New Profile: Lag ny profil
   Profile Manager: Profilbehandler
   All Channels: Alle kanaler

--- a/static/locales/ne.yaml
+++ b/static/locales/ne.yaml
@@ -327,6 +327,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -768,6 +768,8 @@ Profile:
   Custom Color: Eigen kleur
   Color Picker: Kleurselectie
   Edit Profile: Profiel aanpassen
+  Upload Profile Picture: Upload profielfoto
+  Choose an Image: Kies een afbeelding
   Create New Profile: Nieuw profiel aanmaken
   Profile Manager: Profiel beheren
   All Channels: Alle kanalen

--- a/static/locales/nn.yaml
+++ b/static/locales/nn.yaml
@@ -353,6 +353,8 @@ Profile:
   Profile Manager: 'Profilbehandlar'
   Create New Profile: 'Lag ny profil'
   Edit Profile: 'Rediger profil'
+  Upload Profile Picture: 'Last opp profilbilde'
+  Choose an Image: 'Velg et bilde'
   Color Picker: 'Fargeveljar'
   Custom Color: 'Eigendefinert farge'
   Profile Preview: 'Forhandsvising av profil'

--- a/static/locales/or.yaml
+++ b/static/locales/or.yaml
@@ -423,6 +423,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -814,6 +814,8 @@ Profile:
   Custom Color: Własny kolor
   Color Picker: Wybór koloru
   Edit Profile: Edytuj profil
+  Upload Profile Picture: Prześlij zdjęcie profilowe
+  Choose an Image: Wybierz obraz
   Create New Profile: Stwórz nowy profil
   Profile Manager: Menadżer profili
   All Channels: Wszystkie kanały

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -797,6 +797,8 @@ Profile:
   Create Profile: Criar Perfil
   Custom Color: Cor Personalizada
   Edit Profile: Editar Perfil
+  Upload Profile Picture: Carregar foto do perfil
+  Choose an Image: Escolha uma imagem
   Profile Manager: Gerenciador de Perfis
   Profile Select: Seleção de Perfil
   Are you sure you want to delete the selected channels?  This will not delete the channel from any other profile.: Tem

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -456,6 +456,8 @@ Profile:
   Profile Manager: Gestor de perfis
   Create New Profile: Criar novo perfil
   Edit Profile: Editar perfil
+  Upload Profile Picture: Carregar foto do perfil
+  Choose an Image: Escolha uma imagem
   Color Picker: Cor
   Custom Color: Cor personalizada
   Profile Preview: Pré-visualização do perfil

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -506,6 +506,8 @@ Profile:
   Profile Manager: 'Gestor de perfis'
   Create New Profile: 'Criar novo perfil'
   Edit Profile: 'Editar perfil'
+  Upload Profile Picture: Carregar foto do perfil
+  Choose an Image: Escolha uma imagem
   Color Picker: 'Cor'
   Custom Color: 'Cor personalizada'
   Profile Preview: 'Pré-visualização do perfil'

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -484,6 +484,8 @@ Profile:
   Profile Manager: 'Manager de profil'
   Create New Profile: 'Creați un profil nou'
   Edit Profile: 'Editare profil'
+  Upload Profile Picture: 'Încărcați poza de profil'
+  Choose an Image: 'Alegeți o imagine'
   Color Picker: 'Alegător de culori'
   Custom Color: 'Culoare personalizată'
   Profile Preview: 'Previzualizare profil'

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -800,6 +800,8 @@ Profile:
   Custom Color: Свой цвет
   Color Picker: Выбор цвета
   Edit Profile: Изменить профиль
+  Upload Profile Picture: Загрузить изображение профиля
+  Choose an Image: Выберите изображение
   Create New Profile: Создать новый профиль
   Profile Manager: Менеджер профилей
   All Channels: Все каналы

--- a/static/locales/sat.yaml
+++ b/static/locales/sat.yaml
@@ -283,6 +283,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/si.yaml
+++ b/static/locales/si.yaml
@@ -284,6 +284,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -756,6 +756,8 @@ Profile:
   Custom Color: Vlastná farba
   Color Picker: Výber farby
   Edit Profile: Upraviť profil
+  Upload Profile Picture: Nahrajte obrázok profilu
+  Choose an Image: Vyberte obrázok
   Create New Profile: Vytvoriť nový profil
   Profile Manager: Správca profilov
   All Channels: Všetky kanály

--- a/static/locales/sl.yaml
+++ b/static/locales/sl.yaml
@@ -384,6 +384,8 @@ Profile:
   Profile Manager: 'Upravitelj profilov'
   Create New Profile: 'Ustvari nov profil'
   Edit Profile: 'Uredi profil'
+  Upload Profile Picture: 'Naloži sliko profila'
+  Choose an Image: 'Izberite sliko'
   Color Picker: 'Izbiralnik barv'
   Custom Color: 'Barva po meri'
   Profile Preview: 'Predogled profila'

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -325,6 +325,8 @@ Profile:
   Profile Manager: 'Менаџер профила'
   Create New Profile: 'Креирај нови профил'
   Edit Profile: 'Уреди профил'
+  Upload Profile Picture: 'Отпреми слику профила'
+  Choose an Image: 'Изаберите слику'
   Color Picker: 'Селектор боја'
   Custom Color: 'Прилагођена боја'
   Profile Preview: 'Преглед профила'

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -427,6 +427,8 @@ Profile:
   Profile Manager: 'Profilhanterare'
   Create New Profile: 'Skapa ny profil'
   Edit Profile: 'Redigera profil'
+  Upload Profile Picture: 'Ladda upp profilbild'
+  Choose an Image: 'Välj en bild'
   Color Picker: 'Färgväljare'
   Custom Color: 'Anpassad färg'
   Profile Preview: 'Förhandsvisa profil'

--- a/static/locales/tok.yaml
+++ b/static/locales/tok.yaml
@@ -376,6 +376,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -518,6 +518,8 @@ Profile:
   Profile Manager: 'Profil Yöneticisi'
   Create New Profile: 'Yeni Profil Oluştur'
   Edit Profile: 'Profili Düzenle'
+  Upload Profile Picture: 'Profil Resmi Yükle'
+  Choose an Image: 'Bir Resim Seçin'
   Color Picker: 'Renk Seçimi'
   Custom Color: 'Özel Renk'
   Profile Preview: 'Profil Önizleme'

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -493,6 +493,8 @@ Profile:
   Profile Manager: 'Керування профілями'
   Create New Profile: 'Створити новий профіль'
   Edit Profile: 'Редагувати профіль'
+  Upload Profile Picture: 'Завантажити зображення профілю'
+  Choose an Image: 'Виберіть зображення'
   Color Picker: 'Вибір кольору'
   Custom Color: 'Власний колір'
   Profile Preview: 'Попередній перегляд профілю'

--- a/static/locales/ur.yaml
+++ b/static/locales/ur.yaml
@@ -433,6 +433,8 @@ Profile:
   Profile Manager: ''
   Create New Profile: ''
   Edit Profile: ''
+  Upload Profile Picture: ''
+  Choose an Image: ''
   Color Picker: ''
   Custom Color: ''
   Profile Preview: ''

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -777,6 +777,8 @@ Profile:
   Custom Color: Màu custom
   Color Picker: Chọn màu
   Edit Profile: Chỉnh sửa Profile
+  Upload Profile Picture: Tải lên ảnh hồ sơ
+  Choose an Image: Chọn một hình ảnh
   Create New Profile: Tạo Profile mới
   Profile Manager: Quản lý Profile
   All Channels: Tất cả kênh

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -727,6 +727,8 @@ Profile:
   Create Profile: 建立配置文件
   Profile Preview: 配置文件预览
   Edit Profile: 编辑配置文件
+  Upload Profile Picture: 上传头像
+  Choose an Image: 选择图像
   Create New Profile: 建立新配置文件
   Profile Manager: 配置文件管理器
   Custom Color: 自定义颜色

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -739,6 +739,8 @@ Profile:
   Custom Color: 自訂色彩
   Color Picker: 選色器
   Edit Profile: 編輯設定檔
+  Upload Profile Picture: 上傳頭像
+  Choose an Image: 選擇圖像
   Create New Profile: 建立新設定檔
   Profile Manager: 設定檔管理器
   All Channels: 所有頻道


### PR DESCRIPTION
# Profile picture feature

The profile picture feature has two sections: a profile picture and clearer navigation to edit the profile.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #1 #2 #3 #5

## Description
This is the complete profile picture upload & display feature.
- On the profile edit page, there's a button to upload a picture. 
- The profile background image + initial is still an option. 
- The profile picture is displayed wherever profile pictures are displayed. 
- The profile picture is saved to the profile information database.

## Screenshots 
Before, the user's profile is a background color and initial:
![image](https://user-images.githubusercontent.com/19763542/207210829-73326b7b-60b5-422f-82b6-487f0e2e55db.png)

After, upload a photo:
![image](https://user-images.githubusercontent.com/19763542/207211434-7d7901be-f70c-489a-ae20-5fe0af86f4a0.png)

After, profile is updated:
![image](https://user-images.githubusercontent.com/19763542/207211629-46490b35-a100-43de-a144-59fefbdcd84d.png)
